### PR TITLE
Avoid running actions on pushing to main

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,8 +1,6 @@
 name: Flutter Android CI
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
   workflow_dispatch:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,8 +1,6 @@
 name: Flutter Windows CI
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
   workflow_dispatch:


### PR DESCRIPTION
This pull request removes the "push" trigger for the CI workflows on the main branch. The workflows will now only be triggered by pull requests and manual dispatches.